### PR TITLE
fix: change vite config to make `npm run dev` usable

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -23,6 +23,9 @@ export default defineConfig({
                 fileName: '星推荐v2.user.js',
                 sourcemap: 'inline',
             },
+            server: {
+                mountGmApi: true,
+            }
         }),
     ],
 });


### PR DESCRIPTION
现在 `npm run dev` 可以正常使用了